### PR TITLE
fix(dependabot): group updates into two PRs and use existing AVM labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,12 @@ updates:
       time: "06:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
+    groups:
+      terraform:
+        patterns:
+          - "*"
     labels:
-      - dependencies
-      - terraform
+      - "Language: Terraform :globe_with_meridians:"
     commit-message:
       prefix: chore
       include: scope
@@ -37,9 +40,12 @@ updates:
       time: "06:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
-      - dependencies
-      - github-actions
+      - "Type: CI :rocket:"
     commit-message:
       prefix: chore
       include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
     groups:
       terraform:
         patterns:
@@ -39,7 +38,6 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Test PR — Dependabot grouping + label fix

Testbed for the central template change proposed in `Azure/avm-terraform-governance` (issue #174). Mirrors the edit to `managed-files/root/.github/dependabot.yml` so we can validate behavior on a live module repo before the governance change rolls out fleet-wide.

### What changed
- Added a catch-all `groups:` block (`patterns: ["*"]`) to each `package-ecosystem` entry, so this repo gets **at most two open Dependabot PRs**: one grouping all Terraform updates, one grouping all GitHub Actions updates — instead of one PR per dependency.
- Remapped `labels:` to existing AVM standard labels, fixing the "labels could not be found" failures:
  - terraform -> `Language: Terraform :globe_with_meridians:`
  - github-actions -> `Type: CI :rocket:`

### How to test after merge
1. Merge to `main` (Dependabot only reads config from the default branch).
2. Insights -> Dependency graph -> Dependabot -> **Check for updates** to trigger a run immediately.
3. Expect two new grouped PRs with correct labels and no "labels could not be found" comment; existing per-dependency PRs get closed as superseded.

> [!WARNING]
> This repo's `dependabot.yml` is centrally managed by `repository_sync`. This direct change is temporary and may be reverted by the next sync until the governance PR merges.

Ref: Azure/avm-terraform-governance#174 & https://msft.ghe.com/azure-cloud-native/Azure-Verified-Modules/issues/174