### PR TITLE
fix(examples): align versions and network guidance

### DIFF
--- a/examples/every-region/README.md
+++ b/examples/every-region/README.md
@@ -6,12 +6,12 @@ Attempt to create a resource group in every Azure region. This is a simple test 
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.0"
+      version = "~> 2.8"
     }
     random = {
       source  = "hashicorp/random"
@@ -54,9 +54,9 @@ resource "azapi_resource" "this" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 

--- a/examples/every-region/main.tf
+++ b/examples/every-region/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.0"
+      version = "~> 2.8"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/example-a/README.md
+++ b/examples/example-a/README.md
@@ -6,7 +6,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -54,7 +54,7 @@ module "test" {
 
   address_space    = ["10.0.0.0/16"]
   location         = azapi_resource.this.location
-  name             = "rg-test"
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry
 }
@@ -65,7 +65,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
 

--- a/examples/example-a/main.tf
+++ b/examples/example-a/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -47,7 +47,7 @@ module "test" {
 
   address_space    = ["10.0.0.0/16"]
   location         = azapi_resource.this.location
-  name             = "rg-test"
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry
 }

--- a/examples/example-b/README.md
+++ b/examples/example-b/README.md
@@ -6,7 +6,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -54,7 +54,7 @@ module "test" {
 
   address_space    = ["10.0.0.0/16"]
   location         = azapi_resource.this.location
-  name             = "rg-test"
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry
 }
@@ -65,7 +65,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
 

--- a/examples/example-b/main.tf
+++ b/examples/example-b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -47,7 +47,7 @@ module "test" {
 
   address_space    = ["10.0.0.0/16"]
   location         = azapi_resource.this.location
-  name             = "rg-test"
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry
 }

--- a/examples/example-c/README.md
+++ b/examples/example-c/README.md
@@ -6,7 +6,7 @@ This deploys the module in its simplest form.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -54,7 +54,7 @@ module "test" {
 
   address_space    = ["10.0.0.0/16"]
   location         = azapi_resource.this.location
-  name             = "rg-test"
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry
 }
@@ -65,7 +65,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
 

--- a/examples/example-c/main.tf
+++ b/examples/example-c/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -47,7 +47,7 @@ module "test" {
 
   address_space    = ["10.0.0.0/16"]
   location         = azapi_resource.this.location
-  name             = "rg-test"
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry
 }

--- a/examples/ignore_example_for_e2e/README.md
+++ b/examples/ignore_example_for_e2e/README.md
@@ -6,7 +6,7 @@ This example will not be run as an e2e test as it has the .e2eignore file in the
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -48,10 +48,7 @@ resource "azapi_resource" "this" {
   tags     = { test = "test" }
 }
 
-# This is the module call
-# Do not specify location here due to the randomization above.
-# Leaving location as `null` will cause the module to use the resource group location
-# with a data source.
+# This is the module call.
 module "test" {
   source = "../../"
 
@@ -59,7 +56,7 @@ module "test" {
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
   location         = azapi_resource.this.location
-  name             = "TODO" # TODO update with module.naming.<RESOURCE_TYPE>.name_unique
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry # see variables.tf
 }
@@ -70,7 +67,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
 

--- a/examples/ignore_example_for_e2e/main.tf
+++ b/examples/ignore_example_for_e2e/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azapi = {
@@ -41,10 +41,7 @@ resource "azapi_resource" "this" {
   tags     = { test = "test" }
 }
 
-# This is the module call
-# Do not specify location here due to the randomization above.
-# Leaving location as `null` will cause the module to use the resource group location
-# with a data source.
+# This is the module call.
 module "test" {
   source = "../../"
 
@@ -52,7 +49,7 @@ module "test" {
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
   location         = azapi_resource.this.location
-  name             = "TODO" # TODO update with module.naming.<RESOURCE_TYPE>.name_unique
+  name             = module.naming.virtual_network.name_unique
   parent_id        = azapi_resource.this.id
   enable_telemetry = var.enable_telemetry # see variables.tf
 }


### PR DESCRIPTION
## Description

Aligns every example with the root module's Terraform and AzAPI version constraints. It also replaces resource-group-like virtual network names with the naming module's virtual network output and removes unsupported null-location guidance.

Fixes #163
Fixes #165