### PR TITLE
feat: expose requested virtual network address space

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ The following outputs are exported:
 
 Description: Resource name.
 
+### <a name="output_requested_address_space"></a> [requested\_address\_space](#output\_requested\_address\_space)
+
+Description: The virtual network address space requested by the caller. This value is taken directly from the configured input and does not represent values normalized or read back from Azure.
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: Resource ID.

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "name" {
   value       = azapi_resource.this.name
 }
 
+output "requested_address_space" {
+  description = "The virtual network address space requested by the caller. This value is taken directly from the configured input and does not represent values normalized or read back from Azure."
+  value       = var.address_space
+}
+
 output "resource_id" {
   description = "Resource ID."
   value       = azapi_resource.this.id


### PR DESCRIPTION
## Description

Adds a `requested_address_space` output for callers that need to compose other configuration from the exact input supplied to the module.

This output intentionally does not read values back from Azure and does not provide the effective Azure-normalized address space requested in the related issue.

Related context: #160