### PR TITLE
fix: validate virtual network parent resource ID

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "parent_id" {
   type        = string
   description = "The Azure Resource ID of the parent resource (typically the resource group ID) where the resource will be deployed."
   nullable    = false
+
+  validation {
+    condition     = can(provider::azapi::parse_resource_id("Microsoft.Resources/resourceGroups", var.parent_id))
+    error_message = "The parent_id must be a valid resource group resource ID."
+  }
 }
 
 variable "enable_telemetry" {


### PR DESCRIPTION
## Description

Validates the supplied parent resource ID as a resource group during Terraform planning so invalid scopes fail before an Azure request is made.

Related context: #172

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks

---

Fixes #172

<!-- gh-aw-workflow-id: issue-triage -->