### PR TITLE
fix: reject empty virtual network address spaces

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 variable "address_space" {
   type        = list(string)
   description = "The address space that is used by the virtual network."
+  nullable    = false
+
+  validation {
+    condition     = length(var.address_space) > 0
+    error_message = "The address_space must contain at least one address prefix."
+  }
 }
 
 variable "location" {


### PR DESCRIPTION
## Description

Rejects empty virtual network address-space lists during Terraform input validation and disallows null values, producing an actionable error before the provider evaluates the resource.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks