### PR TITLE
docs: clarify optional resource lock configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ This repository serves as a test sandbox for the Azure Verified Modules (AVM) te
 >
 > Do not depend on this module in real workloads. Use a published AVM resource or pattern module instead -- see the [AVM Terraform module index](https://azure.github.io/Azure-Verified-Modules/indexes/terraform/).
 
+## Resource locks
+
+Resource lock creation is disabled by default. Leave `lock` as `null` to deploy the virtual network without a lock, or configure a lock explicitly:
+
+```hcl
+lock = {
+  kind = "CanNotDelete"
+}
+```
+
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 

--- a/_header.md
+++ b/_header.md
@@ -6,3 +6,13 @@ This repository serves as a test sandbox for the Azure Verified Modules (AVM) te
 > **For internal AVM use only.** This module is maintained by the Azure Verified Modules (AVM) team purely as a canary repo for testing governance updates. It does **not** implement any production-ready functionality and is **not** intended for consumption by end users.
 >
 > Do not depend on this module in real workloads. Use a published AVM resource or pattern module instead -- see the [AVM Terraform module index](https://azure.github.io/Azure-Verified-Modules/indexes/terraform/).
+
+## Resource locks
+
+Resource lock creation is disabled by default. Leave `lock` as `null` to deploy the virtual network without a lock, or configure a lock explicitly:
+
+```hcl
+lock = {
+  kind = "CanNotDelete"
+}
+```


### PR DESCRIPTION
## Description

Clarifies that resource lock creation is optional, explains the null default, and adds a concise `CanNotDelete` configuration example to the generated module documentation.

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks

---

Fixes #175

<!-- gh-aw-workflow-id: issue-triage -->