### PR TITLE
feat: support virtual network flow timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_flow_timeout_in_minutes"></a> [flow\_timeout\_in\_minutes](#input\_flow\_timeout\_in\_minutes)
+
+Description: The flow timeout in minutes for the virtual network. Valid values are between 4 and 30.
+
+Type: `number`
+
+Default: `null`
+
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
 Description: Controls the Resource Lock configuration for this resource. The following properties can be specified:

--- a/examples/example-c/README.md
+++ b/examples/example-c/README.md
@@ -52,11 +52,12 @@ resource "azapi_resource" "this" {
 module "test" {
   source = "../../"
 
-  address_space    = ["10.0.0.0/16"]
-  location         = azapi_resource.this.location
-  name             = "rg-test"
-  parent_id        = azapi_resource.this.id
-  enable_telemetry = var.enable_telemetry
+  address_space           = ["10.0.0.0/16"]
+  flow_timeout_in_minutes = 10
+  location                = azapi_resource.this.location
+  name                    = "rg-test"
+  parent_id               = azapi_resource.this.id
+  enable_telemetry        = var.enable_telemetry
 }
 ```
 

--- a/examples/example-c/main.tf
+++ b/examples/example-c/main.tf
@@ -45,9 +45,10 @@ resource "azapi_resource" "this" {
 module "test" {
   source = "../../"
 
-  address_space    = ["10.0.0.0/16"]
-  location         = azapi_resource.this.location
-  name             = "rg-test"
-  parent_id        = azapi_resource.this.id
-  enable_telemetry = var.enable_telemetry
+  address_space           = ["10.0.0.0/16"]
+  flow_timeout_in_minutes = 10
+  location                = azapi_resource.this.location
+  name                    = "rg-test"
+  parent_id               = azapi_resource.this.id
+  enable_telemetry        = var.enable_telemetry
 }

--- a/main.tf
+++ b/main.tf
@@ -4,11 +4,15 @@ resource "azapi_resource" "this" {
   parent_id = var.parent_id
   type      = "Microsoft.Network/virtualNetworks@2025-05-01"
   body = {
-    properties = {
+    properties = merge({
       addressSpace = {
         addressPrefixes = var.address_space
       }
-    }
+      },
+      var.flow_timeout_in_minutes == null ? {} : {
+        flowTimeoutInMinutes = var.flow_timeout_in_minutes
+      }
+    )
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,17 @@ DESCRIPTION
   nullable    = false
 }
 
+variable "flow_timeout_in_minutes" {
+  type        = number
+  default     = null
+  description = "The flow timeout in minutes for the virtual network. Valid values are between 4 and 30."
+
+  validation {
+    condition     = var.flow_timeout_in_minutes == null || try(var.flow_timeout_in_minutes >= 4 && var.flow_timeout_in_minutes <= 30, false)
+    error_message = "The flow_timeout_in_minutes must be between 4 and 30."
+  }
+}
+
 variable "lock" {
   type = object({
     kind = string


### PR DESCRIPTION
## Description

Adds an optional flow-timeout input with Azure range validation, maps it to the virtual network property only when configured, and demonstrates the capability in an example and generated documentation.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks

---

Fixes #173

<!-- gh-aw-workflow-id: issue-triage -->