### PR TITLE
fix: normalize exact duplicate address prefixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "azapi_resource" "this" {
   body = {
     properties = {
       addressSpace = {
-        addressPrefixes = var.address_space
+        addressPrefixes = distinct(var.address_space)
       }
     }
   }


### PR DESCRIPTION
## Description

Normalizes repeated, byte-identical address prefixes before sending the virtual network request. This prevents redundant entries in the common exact-duplicate case.

This change does not detect or reject semantically overlapping ranges such as a `/24` nested inside a `/16`; that reported edge case remains unresolved.

Related context: #171

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks