### PR TITLE
fix: reject blank virtual network locations

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,11 @@ variable "location" {
   type        = string
   description = "Azure region where the resource should be deployed."
   nullable    = false
+
+  validation {
+    condition     = length(trimspace(var.location)) > 0
+    error_message = "The location must not be empty or whitespace."
+  }
 }
 
 variable "name" {


### PR DESCRIPTION
## Description

Adds Terraform input validation that rejects empty or whitespace-only Azure region values before the provider evaluates the virtual network resource.

The reported virtual network name behavior is unchanged; names with surrounding whitespace remain unresolved by this adjacent validation improvement.

Related context: #174

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks