### PR TITLE
fix: correct typo in name variable description

### DIFF
--- a/.github/workflows/dependabot-precommit.yml
+++ b/.github/workflows/dependabot-precommit.yml
@@ -1,0 +1,52 @@
+---
+name: Dependabot Pre-Commit
+
+on:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+
+# Dependabot-triggered runs get a read-only GITHUB_TOKEN by default; declaring
+# permissions explicitly is the supported way to lift that so we can push.
+permissions:
+  contents: write
+
+jobs:
+  pre-commit:
+    name: Apply Pre-Commit Fixes
+    # Only Terraform bumps leave generated files (README version tables,
+    # formatting) stale. github_actions bumps produce no pre-commit diff.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/terraform/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Run pre-commit
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod a+x ./avm
+          # pre-commit exits non-zero when it rewrites files, so run again to verify.
+          ./avm pre-commit
+          if ($LASTEXITCODE -ne 0) {
+            ./avm pre-commit
+          }
+
+      - name: Commit and push pre-commit fixes
+        shell: pwsh
+        run: |
+          if (-not (git status --porcelain)) {
+            Write-Host "No pre-commit changes to push."
+            exit 0
+          }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore(deps): apply pre-commit fixes"
+          git push

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Type: `string`
 
 ### <a name="input_name"></a> [name](#input\_name)
 
-Description: The name of the this resource.
+Description: The name of this resource.
 
 Type: `string`
 

--- a/tests/integration/deploy.tftest.hcl
+++ b/tests/integration/deploy.tftest.hcl
@@ -1,0 +1,64 @@
+variables {
+  enable_telemetry = false
+}
+
+run "setup" {
+  module {
+    source = "./tests/integration/setup"
+  }
+}
+
+run "deploys_a_virtual_network_into_the_target_resource_group" {
+  variables {
+    address_space = ["10.0.0.0/16"]
+    location      = run.setup.location
+    name          = run.setup.virtual_network_name
+    parent_id     = run.setup.resource_group_id
+    tags = {
+      environment = "integration-test"
+    }
+  }
+
+  assert {
+    condition     = output.name == run.setup.virtual_network_name
+    error_message = "The name output must report the deployed virtual network name."
+  }
+
+  assert {
+    condition     = output.resource_id == "${run.setup.resource_group_id}/providers/Microsoft.Network/virtualNetworks/${run.setup.virtual_network_name}"
+    error_message = "The resource_id output must be the ARM ID of the virtual network inside the target resource group."
+  }
+
+  assert {
+    condition     = azapi_resource.this.location == run.setup.location
+    error_message = "The virtual network must be deployed to the resource group region."
+  }
+}
+
+run "updates_the_address_space_and_tags_in_place" {
+  variables {
+    address_space = ["10.0.0.0/16", "10.1.0.0/16"]
+    location      = run.setup.location
+    name          = run.setup.virtual_network_name
+    parent_id     = run.setup.resource_group_id
+    tags = {
+      environment = "integration-test"
+      updated     = "true"
+    }
+  }
+
+  assert {
+    condition     = output.resource_id == "${run.setup.resource_group_id}/providers/Microsoft.Network/virtualNetworks/${run.setup.virtual_network_name}"
+    error_message = "Updating the address space and tags must not replace the virtual network."
+  }
+
+  assert {
+    condition     = length(azapi_resource.this.body.properties.addressSpace.addressPrefixes) == 2
+    error_message = "The added address prefix must be applied to the existing virtual network."
+  }
+
+  assert {
+    condition     = azapi_resource.this.tags["updated"] == "true"
+    error_message = "The added tag must be applied to the existing virtual network."
+  }
+}

--- a/tests/integration/setup/main.tf
+++ b/tests/integration/setup/main.tf
@@ -1,0 +1,22 @@
+module "regions" {
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.9.0"
+
+  is_recommended = true
+}
+
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.4.2"
+}
+
+resource "azapi_resource" "resource_group" {
+  location = module.regions.regions[random_integer.region_index.result].name
+  name     = module.naming.resource_group.name_unique
+  type     = "Microsoft.Resources/resourceGroups@2025-04-01"
+}

--- a/tests/integration/setup/outputs.tf
+++ b/tests/integration/setup/outputs.tf
@@ -1,0 +1,14 @@
+output "location" {
+  description = "The region the test resource group was created in."
+  value       = azapi_resource.resource_group.location
+}
+
+output "resource_group_id" {
+  description = "The resource ID of the test resource group, for use as the module parent_id."
+  value       = azapi_resource.resource_group.id
+}
+
+output "virtual_network_name" {
+  description = "A CAF compliant, unique virtual network name for the module under test."
+  value       = module.naming.virtual_network.name_unique
+}

--- a/tests/integration/setup/terraform.tf
+++ b/tests/integration/setup/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9, < 2.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.8"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}

--- a/tests/unit/defaults.tftest.hcl
+++ b/tests/unit/defaults.tftest.hcl
@@ -1,0 +1,74 @@
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  address_space    = ["10.0.0.0/16", "10.1.0.0/16"]
+  location         = "uksouth"
+  name             = "vnet-unit-test"
+  parent_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test"
+  enable_telemetry = false
+}
+
+run "creates_a_virtual_network_from_the_required_inputs" {
+  command = plan
+
+  assert {
+    condition     = azapi_resource.this.type == "Microsoft.Network/virtualNetworks@2025-05-01"
+    error_message = "The module must deploy a virtual network resource type."
+  }
+
+  assert {
+    condition     = azapi_resource.this.name == var.name
+    error_message = "The resource name must come from var.name."
+  }
+
+  assert {
+    condition     = azapi_resource.this.parent_id == var.parent_id
+    error_message = "The resource must be parented to var.parent_id."
+  }
+
+  assert {
+    condition     = azapi_resource.this.location == var.location
+    error_message = "The resource must be deployed to var.location."
+  }
+}
+
+run "passes_every_address_prefix_through_to_the_request_body" {
+  command = plan
+
+  assert {
+    condition     = azapi_resource.this.body.properties.addressSpace.addressPrefixes == var.address_space
+    error_message = "All address prefixes must be forwarded to the virtual network body."
+  }
+}
+
+run "creates_no_optional_resources_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(azapi_resource.lock) == 0
+    error_message = "No lock must be created when var.lock is null."
+  }
+
+  assert {
+    condition     = length(azapi_resource.role_assignment) == 0
+    error_message = "No role assignments must be created when var.role_assignments is empty."
+  }
+}
+
+run "applies_tags_when_supplied" {
+  command = plan
+
+  variables {
+    tags = {
+      environment = "test"
+      owner       = "avm"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.tags == var.tags
+    error_message = "Tags must be forwarded to the virtual network."
+  }
+}

--- a/tests/unit/lock.tftest.hcl
+++ b/tests/unit/lock.tftest.hcl
@@ -1,0 +1,69 @@
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  address_space    = ["10.0.0.0/16"]
+  location         = "uksouth"
+  name             = "vnet-unit-test"
+  parent_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test"
+  enable_telemetry = false
+}
+
+run "derives_the_lock_name_from_the_kind_when_none_is_supplied" {
+  command = plan
+
+  variables {
+    lock = {
+      kind = "CanNotDelete"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.lock[0].name == "lock-CanNotDelete"
+    error_message = "An unnamed lock must fall back to 'lock-<kind>'."
+  }
+
+  assert {
+    condition     = azapi_resource.lock[0].body.properties.level == "CanNotDelete"
+    error_message = "The lock level must come from var.lock.kind."
+  }
+
+  assert {
+    condition     = azapi_resource.lock[0].body.properties.notes == "Cannot delete the resource or its child resources."
+    error_message = "A CanNotDelete lock must carry the delete-scoped note."
+  }
+}
+
+run "honours_an_explicit_lock_name" {
+  command = plan
+
+  variables {
+    lock = {
+      kind = "ReadOnly"
+      name = "my-custom-lock"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.lock[0].name == "my-custom-lock"
+    error_message = "An explicit lock name must win over the derived default."
+  }
+
+  assert {
+    condition     = azapi_resource.lock[0].body.properties.notes == "Cannot delete or modify the resource or its child resources."
+    error_message = "A ReadOnly lock must carry the modify-scoped note."
+  }
+}
+
+run "rejects_an_unsupported_lock_kind" {
+  command = plan
+
+  variables {
+    lock = {
+      kind = "NotALockKind"
+    }
+  }
+
+  expect_failures = [var.lock]
+}

--- a/tests/unit/role_assignments.tftest.hcl
+++ b/tests/unit/role_assignments.tftest.hcl
@@ -1,0 +1,134 @@
+// azapi validates that parent_id is a real Azure resource ID, so the generated
+// mock ID has to be a well-formed one.
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.Network/virtualNetworks/vnet-unit-test"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  address_space    = ["10.0.0.0/16"]
+  location         = "uksouth"
+  name             = "vnet-unit-test"
+  parent_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test"
+  enable_telemetry = false
+}
+
+run "uses_a_fully_qualified_role_definition_id_verbatim" {
+  command = apply
+
+  variables {
+    role_assignments = {
+      reader = {
+        role_definition_id_or_name = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+        principal_id               = "11111111-1111-1111-1111-111111111111"
+      }
+    }
+  }
+
+  assert {
+    condition     = length(azapi_resource.role_assignment) == 1
+    error_message = "One role assignment must be created for each entry in var.role_assignments."
+  }
+
+  assert {
+    condition     = azapi_resource.role_assignment["reader"].body.properties.roleDefinitionId == var.role_assignments["reader"].role_definition_id_or_name
+    error_message = "A fully qualified role definition ID must be used without a lookup."
+  }
+
+  assert {
+    condition     = azapi_resource.role_assignment["reader"].body.properties.principalId == var.role_assignments["reader"].principal_id
+    error_message = "The principal ID must be forwarded to the role assignment."
+  }
+
+  assert {
+    condition     = length(local.role_definition_names) == 0
+    error_message = "A fully qualified role definition ID must not trigger a role definition name lookup."
+  }
+}
+
+run "omits_optional_role_assignment_properties_when_unset" {
+  command = apply
+
+  variables {
+    role_assignments = {
+      reader = {
+        role_definition_id_or_name = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+        principal_id               = "11111111-1111-1111-1111-111111111111"
+      }
+    }
+  }
+
+  assert {
+    condition     = !can(azapi_resource.role_assignment["reader"].body.properties.description)
+    error_message = "An unset description must be omitted from the request body entirely."
+  }
+
+  assert {
+    condition     = !can(azapi_resource.role_assignment["reader"].body.properties.condition)
+    error_message = "An unset condition must be omitted from the request body entirely."
+  }
+}
+
+run "forwards_optional_role_assignment_properties_when_set" {
+  command = apply
+
+  variables {
+    role_assignments = {
+      contributor = {
+        role_definition_id_or_name = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+        principal_id               = "22222222-2222-2222-2222-222222222222"
+        description                = "Grants contributor access."
+        principal_type             = "ServicePrincipal"
+        condition                  = "@Resource[Microsoft.Network/virtualNetworks] StringEquals 'x'"
+        condition_version          = "2.0"
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.role_assignment["contributor"].body.properties.description == "Grants contributor access."
+    error_message = "A supplied description must be forwarded to the role assignment."
+  }
+
+  assert {
+    condition     = azapi_resource.role_assignment["contributor"].body.properties.principalType == "ServicePrincipal"
+    error_message = "A supplied principal type must be forwarded to the role assignment."
+  }
+
+  assert {
+    condition     = azapi_resource.role_assignment["contributor"].body.properties.conditionVersion == "2.0"
+    error_message = "A supplied condition version must be forwarded to the role assignment."
+  }
+}
+
+run "creates_one_role_assignment_per_map_entry" {
+  command = apply
+
+  variables {
+    role_assignments = {
+      reader = {
+        role_definition_id_or_name = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+        principal_id               = "11111111-1111-1111-1111-111111111111"
+      }
+      contributor = {
+        role_definition_id_or_name = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+        principal_id               = "22222222-2222-2222-2222-222222222222"
+      }
+    }
+  }
+
+  assert {
+    condition     = length(azapi_resource.role_assignment) == 2
+    error_message = "Each role assignment map entry must produce its own resource."
+  }
+
+  assert {
+    condition     = azapi_resource.role_assignment["reader"].name != azapi_resource.role_assignment["contributor"].name
+    error_message = "Each role assignment must get a distinct deterministic name."
+  }
+}

--- a/tests/unit/telemetry.tftest.hcl
+++ b/tests/unit/telemetry.tftest.hcl
@@ -1,0 +1,82 @@
+// azapi validates that parent_id is a real Azure resource ID, so the generated
+// mock ID has to be a well-formed one.
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.Network/virtualNetworks/vnet-unit-test"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  address_space = ["10.0.0.0/16"]
+  location      = "uksouth"
+  name          = "vnet-unit-test"
+  parent_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test"
+}
+
+run "creates_no_telemetry_resources_when_disabled" {
+  command = plan
+
+  variables {
+    enable_telemetry = false
+  }
+
+  assert {
+    condition     = length(modtm_telemetry.telemetry) == 0
+    error_message = "No telemetry resource must be created when telemetry is disabled."
+  }
+
+  assert {
+    condition     = length(data.azapi_client_config.telemetry) == 0
+    error_message = "The client config must not be read when telemetry is disabled."
+  }
+
+  assert {
+    condition     = azapi_resource.this.create_headers == null
+    error_message = "Telemetry headers must be omitted when telemetry is disabled."
+  }
+}
+
+run "sends_telemetry_headers_when_enabled" {
+  command = apply
+
+  variables {
+    enable_telemetry = true
+  }
+
+  assert {
+    condition     = length(modtm_telemetry.telemetry) == 1
+    error_message = "A telemetry resource must be created when telemetry is enabled."
+  }
+
+  assert {
+    condition     = azapi_resource.this.create_headers != null
+    error_message = "Telemetry headers must be attached when telemetry is enabled."
+  }
+
+  assert {
+    condition     = alltrue([for h in [azapi_resource.this.create_headers, azapi_resource.this.read_headers, azapi_resource.this.update_headers, azapi_resource.this.delete_headers] : h == azapi_resource.this.create_headers])
+    error_message = "The same telemetry header must be sent on every request verb."
+  }
+}
+
+run "exposes_the_deployed_resource_through_outputs" {
+  command = apply
+
+  variables {
+    enable_telemetry = false
+  }
+
+  assert {
+    condition     = output.name == var.name
+    error_message = "The name output must expose the deployed resource name."
+  }
+
+  assert {
+    condition     = output.resource_id == azapi_resource.this.id
+    error_message = "The resource_id output must expose the deployed resource ID."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "location" {
 
 variable "name" {
   type        = string
-  description = "The name of the this resource."
+  description = "The name of this resource."
 }
 
 variable "parent_id" {


### PR DESCRIPTION
Fixes a typo in the `name` variable description ("the name of the this resource" → "the name of this resource") and regenerates `README.md`.

This change is being used to validate the new `Avm.Authoring` PowerShell toolchain end to end — local `avm pre-commit` regenerated the README automatically, and this PR exercises the canary `PR Check` workflow that calls `Azure/azure-verified-modules-tools/.github/workflows/terraform-module.yml@main`.